### PR TITLE
Modern CMake Build fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.6)
 
 project(cquadpack C)
 

--- a/include/cquadpack.h
+++ b/include/cquadpack.h
@@ -1,120 +1,157 @@
 #define _USE_MATH_DEFINES
-#include <math.h>
 #include <float.h>
+#include <math.h>
 
 #include "cquadpack_export.h"
 
-#define uflow     DBL_MIN
-#define oflow     DBL_MAX
-#define epmach     DBL_EPSILON
-#define LIMIT     500
-#define MAXP1     21
+#define uflow DBL_MIN
+#define oflow DBL_MAX
+#define epmach DBL_EPSILON
+#define LIMIT 500
+#define MAXP1 21
 #ifdef M_PI
-#define Pi      M_PI
+#define Pi M_PI
 #else
-#define Pi      3.14159265358979323846
+#define Pi 3.14159265358979323846
 #endif
-#define COSINE     1
-#define SINE    2
+#define COSINE 1
+#define SINE 2
 
 #ifndef FALSE
-#define FALSE   0
+#define FALSE 0
 #endif
 #ifndef TRUE
-#define TRUE    1
+#define TRUE 1
 #endif
 #ifndef min
-#define min(a,b)    (((a) < (b)) ? (a) : (b))
+#define min(a, b) (((a) < (b)) ? (a) : (b))
 #endif
 #ifndef max
-#define max(a,b)    (((a) > (b)) ? (a) : (b))
+#define max(a, b) (((a) > (b)) ? (a) : (b))
 #endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
 
-typedef double(*dq_function_type)(double, void*);
+typedef double (*dq_function_type)(double, void *);
+typedef double (*dq_weight_function_type)(double, double, double, double,
+                                          double, int);
 
 /* Integration routines */
 /* Gauss-Kronrod for integration over finite range. */
-CQUADPACK_EXPORT double G_K15(dq_function_type f,double a,double b,double *abserr,
-    double *resabs, double *resasc, void* user_data);
-CQUADPACK_EXPORT double G_K21(dq_function_type f, double a, double b, double *abserr,
-    double *resabs, double *resasc, void* user_data);
-CQUADPACK_EXPORT double G_K31(dq_function_type f, double a, double b, double *abserr,
-    double *resabs, double *resasc, void* user_data);
-CQUADPACK_EXPORT double G_K41(dq_function_type f, double a, double b, double *abserr,
-    double *resabs, double *resasc, void* user_data);
-CQUADPACK_EXPORT double G_K51(dq_function_type f, double a, double b, double *abserr,
-    double *resabs, double *resasc, void* user_data);
-CQUADPACK_EXPORT double G_K61(dq_function_type f, double a, double b, double *abserr,
-    double *resabs, double *resasc, void* user_data);
+CQUADPACK_EXPORT double G_K15(dq_function_type f, double a, double b,
+                              double *abserr, double *resabs, double *resasc,
+                              void *user_data);
+CQUADPACK_EXPORT double G_K21(dq_function_type f, double a, double b,
+                              double *abserr, double *resabs, double *resasc,
+                              void *user_data);
+CQUADPACK_EXPORT double G_K31(dq_function_type f, double a, double b,
+                              double *abserr, double *resabs, double *resasc,
+                              void *user_data);
+CQUADPACK_EXPORT double G_K41(dq_function_type f, double a, double b,
+                              double *abserr, double *resabs, double *resasc,
+                              void *user_data);
+CQUADPACK_EXPORT double G_K51(dq_function_type f, double a, double b,
+                              double *abserr, double *resabs, double *resasc,
+                              void *user_data);
+CQUADPACK_EXPORT double G_K61(dq_function_type f, double a, double b,
+                              double *abserr, double *resabs, double *resasc,
+                              void *user_data);
 
 /* Gauss-Kronrod for integration over infinite range. */
-CQUADPACK_EXPORT double G_K15I(dq_function_type f, double boun, int inf, double a, double b,
-    double *abserr,double *resabs, double *resasc, void* user_data);
+CQUADPACK_EXPORT double G_K15I(dq_function_type f, double boun, int inf,
+                               double a, double b, double *abserr,
+                               double *resabs, double *resasc, void *user_data);
 
 /* Gauss-Kronrod for integration of weighted function. */
-CQUADPACK_EXPORT double G_K15W(dq_function_type f, double w(), double p1, double p2, double p3,
-    double p4,int kp,double a,double b,double *abserr,
-    double *resabs, double *resasc, void* user_data);
-CQUADPACK_EXPORT double dqext(int *n, double epstab [], double *abserr,
-    double res3la[],int *nres);
+CQUADPACK_EXPORT double G_K15W(dq_function_type f, dq_weight_function_type w,
+                               double p1, double p2, double p3, double p4,
+                               int kp, double a, double b, double *abserr,
+                               double *resabs, double *resasc, void *user_data);
+CQUADPACK_EXPORT double dqext(int *n, double epstab[], double *abserr,
+                              double res3la[], int *nres);
 CQUADPACK_EXPORT void dqsort(int limit, int last, int *maxerr, double *ermax,
-    double elist[],int iord[],int *nrmax);
-CQUADPACK_EXPORT double dqagi(dq_function_type f, double bound, int inf, double epsabs,
-    double epsrel,double *abserr,int *neval,int *ier, void* user_data);
-CQUADPACK_EXPORT double dqags(dq_function_type f, double a, double b, double epsabs,
-    double epsrel,double *abserr,int *neval,int *ier, void* user_data);
-CQUADPACK_EXPORT double dqagp(dq_function_type f, double a, double b, int npts2, double *points,
-    double epsabs,double epsrel,double *abserr,int *neval,int *ier, void* user_data);
-CQUADPACK_EXPORT double dqng(dq_function_type f, double a, double b, double epsabs, double epsrel,
-    double *abserr,int *neval,int *ier, void* user_data);
-CQUADPACK_EXPORT double dqag(dq_function_type f, double a, double b, double epsabs, double epsrel,
-    int irule,double *abserr,int *neval,int *ier, void* user_data);
-CQUADPACK_EXPORT double dqage(dq_function_type f, double a, double b, double epsabs, double epsrel,
-    int irule,double *abserr,int *neval,int *ier,int *last, void* user_data);
-CQUADPACK_EXPORT double dqwgtc(double x, double c, double p2, double p3, double p4,
-    int kp);
-CQUADPACK_EXPORT double dqwgto(double x, double omega, double p2, double p3, double p4,
-    int integr);
-CQUADPACK_EXPORT double dqwgts(double x, double a, double b, double alpha, double beta,
-    int integr);
-CQUADPACK_EXPORT void dqcheb(double *x, double *fval, double *cheb12, double *cheb24);
-CQUADPACK_EXPORT double dqc25o(dq_function_type f, double a, double b, double omega, int integr,
-    int nrmom,int maxp1,int ksave,double *abserr,int *neval,
-    double *resabs,double *resasc,int *momcom,double **chebmo, void* user_data);
-CQUADPACK_EXPORT double dqfour(dq_function_type f, double a, double b, double omega, int integr,
-    double epsabs,double epsrel,int icall,int maxp1,
-    double *abserr,int *neval,int *ier,int *momcom,
-    double **chebmo, void* user_data);
-CQUADPACK_EXPORT double dqawfe(dq_function_type f, double a, double omega, int integr, double epsabs,
-    int limlst,int maxp1,double *abserr,int *neval,int *ier,
-    double *rslst,double *erlist,int *ierlst,double **chebmo, void* user_data);
-CQUADPACK_EXPORT double dqawf(dq_function_type f, double a, double omega, int integr, double epsabs,
-    double *abserr,int *neval,int *ier, void* user_data);
-CQUADPACK_EXPORT double dqawo(dq_function_type f, double a, double b, double omega, int integr, double epsabs,
-    double epsrel,double *abserr,int *neval,int *ier, void* user_data);
-CQUADPACK_EXPORT double dqaws(dq_function_type f, double a, double b, double alfa, double beta, int wgtfunc,
-    double epsabs,double epsrel,double *abserr,int *neval,int *ier, void* user_data);
-CQUADPACK_EXPORT double dqawse(dq_function_type f, double a, double b, double alfa, double beta,
-    int wgtfunc,double epsabs,double epsrel,double *abserr,
-    int *neval,int *ier, void* user_data);
-CQUADPACK_EXPORT void dqmomo(double alfa, double beta, double ri [], double rj [], double rg [],
-    double rh[],int wgtfunc);
-CQUADPACK_EXPORT double dqc25s(dq_function_type f, double a, double b, double bl, double br, double alfa,
-    double beta,double ri[],double rj[],double rg[],double rh[],
-    double *abserr,double *resasc,int wgtfunc,int *nev, void* user_data);
-CQUADPACK_EXPORT double dqc25c(dq_function_type f, double a, double b, double c, double *abserr,
-    int *krul,int *neval, void* user_data);
-CQUADPACK_EXPORT double dqawc(dq_function_type f, double a, double b, double c, double epsabs,
-    double epsrel,double *abserr,int *neval,int *ier, void* user_data);
-CQUADPACK_EXPORT double dqawce(dq_function_type f, double a, double b, double c, double epsabs,
-    double epsrel,double *abserr,int *neval,int *ier, void* user_data);
+                             double elist[], int iord[], int *nrmax);
+CQUADPACK_EXPORT double dqagi(dq_function_type f, double bound, int inf,
+                              double epsabs, double epsrel, double *abserr,
+                              int *neval, int *ier, void *user_data);
+CQUADPACK_EXPORT double dqags(dq_function_type f, double a, double b,
+                              double epsabs, double epsrel, double *abserr,
+                              int *neval, int *ier, void *user_data);
+CQUADPACK_EXPORT double dqagp(dq_function_type f, double a, double b, int npts2,
+                              double *points, double epsabs, double epsrel,
+                              double *abserr, int *neval, int *ier,
+                              void *user_data);
+CQUADPACK_EXPORT double dqng(dq_function_type f, double a, double b,
+                             double epsabs, double epsrel, double *abserr,
+                             int *neval, int *ier, void *user_data);
+CQUADPACK_EXPORT double dqag(dq_function_type f, double a, double b,
+                             double epsabs, double epsrel, int irule,
+                             double *abserr, int *neval, int *ier,
+                             void *user_data);
+CQUADPACK_EXPORT double dqage(dq_function_type f, double a, double b,
+                              double epsabs, double epsrel, int irule,
+                              double *abserr, int *neval, int *ier, int *last,
+                              void *user_data);
+CQUADPACK_EXPORT double dqwgtc(double x, double c, double p2, double p3,
+                               double p4, int kp);
+CQUADPACK_EXPORT double dqwgto(double x, double omega, double p2, double p3,
+                               double p4, int integr);
+CQUADPACK_EXPORT double dqwgts(double x, double a, double b, double alpha,
+                               double beta, int integr);
+CQUADPACK_EXPORT void dqcheb(double *x, double *fval, double *cheb12,
+                             double *cheb24);
+CQUADPACK_EXPORT double dqc25o(dq_function_type f, double a, double b,
+                               double omega, int integr, int nrmom, int maxp1,
+                               int ksave, double *abserr, int *neval,
+                               double *resabs, double *resasc, int *momcom,
+                               double **chebmo, void *user_data);
+CQUADPACK_EXPORT double dqfour(dq_function_type f, double a, double b,
+                               double omega, int integr, double epsabs,
+                               double epsrel, int icall, int maxp1,
+                               double *abserr, int *neval, int *ier,
+                               int *momcom, double **chebmo, void *user_data);
+CQUADPACK_EXPORT double dqawfe(dq_function_type f, double a, double omega,
+                               int integr, double epsabs, int limlst, int maxp1,
+                               double *abserr, int *neval, int *ier,
+                               double *rslst, double *erlist, int *ierlst,
+                               double **chebmo, void *user_data);
+CQUADPACK_EXPORT double dqawf(dq_function_type f, double a, double omega,
+                              int integr, double epsabs, double *abserr,
+                              int *neval, int *ier, void *user_data);
+CQUADPACK_EXPORT double dqawo(dq_function_type f, double a, double b,
+                              double omega, int integr, double epsabs,
+                              double epsrel, double *abserr, int *neval,
+                              int *ier, void *user_data);
+CQUADPACK_EXPORT double dqaws(dq_function_type f, double a, double b,
+                              double alfa, double beta, int wgtfunc,
+                              double epsabs, double epsrel, double *abserr,
+                              int *neval, int *ier, void *user_data);
+CQUADPACK_EXPORT double dqawse(dq_function_type f, double a, double b,
+                               double alfa, double beta, int wgtfunc,
+                               double epsabs, double epsrel, double *abserr,
+                               int *neval, int *ier, void *user_data);
+CQUADPACK_EXPORT void dqmomo(double alfa, double beta, double ri[], double rj[],
+                             double rg[], double rh[], int wgtfunc);
+CQUADPACK_EXPORT double dqc25s(dq_function_type f, double a, double b,
+                               double bl, double br, double alfa, double beta,
+                               double ri[], double rj[], double rg[],
+                               double rh[], double *abserr, double *resasc,
+                               int wgtfunc, int *nev, void *user_data);
+CQUADPACK_EXPORT double dqc25c(dq_function_type f, double a, double b, double c,
+                               double *abserr, int *krul, int *neval,
+                               void *user_data);
+CQUADPACK_EXPORT double dqawc(dq_function_type f, double a, double b, double c,
+                              double epsabs, double epsrel, double *abserr,
+                              int *neval, int *ier, void *user_data);
+CQUADPACK_EXPORT double dqawce(dq_function_type f, double a, double b, double c,
+                               double epsabs, double epsrel, double *abserr,
+                               int *neval, int *ier, void *user_data);
 
-CQUADPACK_EXPORT double G_B15(dq_function_type f, double a, double b, double *abserr,
-    double *resabs, double *resasc, void* user_data);
+CQUADPACK_EXPORT double G_B15(dq_function_type f, double a, double b,
+                              double *abserr, double *resabs, double *resasc,
+                              void *user_data);
 
 #ifdef __cplusplus
 }

--- a/src/dqk15w.c
+++ b/src/dqk15w.c
@@ -1,85 +1,71 @@
 #include "cquadpack.h"
 
-double G_K15W(dq_function_type f,double w(),double p1,double p2,double p3,
-    double p4,int kp,double a,double b,double *abserr,
-    double *resabs,double *resasc, void* user_data)
-{
-    static double XGK15[8] = {
-        0.99145537112081263921,
-        0.94910791234275852453,
-        0.86486442335976907279,
-        0.74153118559939443986,
-        0.58608723546769113029,
-        0.40584515137739716691,
-        0.20778495500789846760,
-        0.00000000000000000000};
-    static double WGK15[8] = {
-        0.02293532201052922496,
-        0.06309209262997855329,
-        0.10479001032225018384,
-        0.14065325971552591875,
-        0.16900472663926790283,
-        0.19035057806478540991,
-        0.20443294007529889241,
-        0.20948214108472782801};
-    static double WG7[4] = {
-        0.12948496616886969327,
-        0.27970539148927666790,
-        0.38183005050511894495,
-        0.41795918367346938776};
-    double fv1[7],fv2[7];
-    double absc,absc1,absc2,centr,dhlgth;
-    double fc,fsum,fval1,fval2,hlgth;
-    double resg,resk,reskh,result;
-    int j,jtw,jtwm1;
+double G_K15W(dq_function_type f, dq_weight_function_type w, double p1,
+              double p2, double p3, double p4, int kp, double a, double b,
+              double *abserr, double *resabs, double *resasc, void *user_data) {
+  static double XGK15[8] = {0.99145537112081263921, 0.94910791234275852453,
+                            0.86486442335976907279, 0.74153118559939443986,
+                            0.58608723546769113029, 0.40584515137739716691,
+                            0.20778495500789846760, 0.00000000000000000000};
+  static double WGK15[8] = {0.02293532201052922496, 0.06309209262997855329,
+                            0.10479001032225018384, 0.14065325971552591875,
+                            0.16900472663926790283, 0.19035057806478540991,
+                            0.20443294007529889241, 0.20948214108472782801};
+  static double WG7[4] = {0.12948496616886969327, 0.27970539148927666790,
+                          0.38183005050511894495, 0.41795918367346938776};
+  double fv1[7], fv2[7];
+  double absc, absc1, absc2, centr, dhlgth;
+  double fc, fsum, fval1, fval2, hlgth;
+  double resg, resk, reskh, result;
+  int j, jtw, jtwm1;
 
-    centr = 0.5 * (a + b);
-    hlgth = 0.5 * (b - a);
-    dhlgth = fabs(hlgth);
+  centr = 0.5 * (a + b);
+  hlgth = 0.5 * (b - a);
+  dhlgth = fabs(hlgth);
 
-    fc=(*f)(centr, user_data) * (*w)(centr,p1,p2,p3,p4,kp);
-    resg = fc * WG7[3];
-    resk = fc * WGK15[7];
-    *resabs = fabs(resk);
-    for (j = 0; j < 3; j++) {
-        jtw = 2 * j + 1;
-        absc = hlgth * XGK15[jtw];
-        absc1 = centr - absc;
-        absc2 = centr + absc;
-        fval1 = (*f)(absc1, user_data) * (*w)(absc1, p1, p2, p3, p4, kp);
-        fval2 = (*f)(absc2, user_data) * (*w)(absc2, p1, p2, p3, p4, kp);
-        fv1[jtw] = fval1;
-        fv2[jtw] = fval2;
-        fsum = fval1 + fval2;
-        resg += WG7[j] * fsum;
-        resk += WGK15[jtw] * fsum;
-        *resabs = *resabs + WGK15[jtw] * (fabs(fval1) + fabs(fval2));
-    }
-    for (j = 0; j < 4; j++) {
-        jtwm1 = j * 2;
-        absc = hlgth * XGK15[jtwm1];
-        absc1 = centr - absc;
-        absc2 = centr + absc;
-        fval1 = (*f)(absc1, user_data) * (*w)(absc1, p1, p2, p3, p4, kp);
-        fval2 = (*f)(absc2, user_data) * (*w)(absc2, p1, p2, p3, p4, kp);
-        fv1[jtwm1] = fval1;
-        fv2[jtwm1] = fval2;
-        fsum = fval1 + fval2;
-        resk = resk + WGK15[jtwm1] * fsum;
-        *resabs = (*resabs) + WGK15[jtwm1] * (fabs(fval1) + fabs(fval2));
-    }
-    reskh = resk * 0.5;
-    *resasc = WGK15[7] * fabs(fc - reskh);
-    for (j = 0; j < 7; j++ )
-        *resasc = (*resasc) + WGK15[j] * (fabs(fv1[j] - reskh) +
-            fabs(fv2[j] - reskh));
-    result = resk * hlgth;
-    *resabs = (*resabs) * dhlgth;
-    *resasc = (*resasc) * dhlgth;
-    *abserr = fabs((resk - resg) * hlgth);
-    if ((*resasc != 0.0) && (*abserr != 0.0))
-        *abserr = (*resasc) * min(1.0,pow((200.0 * (*abserr)/(*resasc)),1.5));
-    if (*resabs > uflow/(50.0 * epmach))
-        *abserr = max(epmach * 50.0 * (*resabs),(*abserr));
-    return result;
+  fc = (*f)(centr, user_data) * (*w)(centr, p1, p2, p3, p4, kp);
+  resg = fc * WG7[3];
+  resk = fc * WGK15[7];
+  *resabs = fabs(resk);
+  for (j = 0; j < 3; j++) {
+    jtw = 2 * j + 1;
+    absc = hlgth * XGK15[jtw];
+    absc1 = centr - absc;
+    absc2 = centr + absc;
+    fval1 = (*f)(absc1, user_data) * (*w)(absc1, p1, p2, p3, p4, kp);
+    fval2 = (*f)(absc2, user_data) * (*w)(absc2, p1, p2, p3, p4, kp);
+    fv1[jtw] = fval1;
+    fv2[jtw] = fval2;
+    fsum = fval1 + fval2;
+    resg += WG7[j] * fsum;
+    resk += WGK15[jtw] * fsum;
+    *resabs = *resabs + WGK15[jtw] * (fabs(fval1) + fabs(fval2));
+  }
+  for (j = 0; j < 4; j++) {
+    jtwm1 = j * 2;
+    absc = hlgth * XGK15[jtwm1];
+    absc1 = centr - absc;
+    absc2 = centr + absc;
+    fval1 = (*f)(absc1, user_data) * (*w)(absc1, p1, p2, p3, p4, kp);
+    fval2 = (*f)(absc2, user_data) * (*w)(absc2, p1, p2, p3, p4, kp);
+    fv1[jtwm1] = fval1;
+    fv2[jtwm1] = fval2;
+    fsum = fval1 + fval2;
+    resk = resk + WGK15[jtwm1] * fsum;
+    *resabs = (*resabs) + WGK15[jtwm1] * (fabs(fval1) + fabs(fval2));
+  }
+  reskh = resk * 0.5;
+  *resasc = WGK15[7] * fabs(fc - reskh);
+  for (j = 0; j < 7; j++)
+    *resasc =
+        (*resasc) + WGK15[j] * (fabs(fv1[j] - reskh) + fabs(fv2[j] - reskh));
+  result = resk * hlgth;
+  *resabs = (*resabs) * dhlgth;
+  *resasc = (*resasc) * dhlgth;
+  *abserr = fabs((resk - resg) * hlgth);
+  if ((*resasc != 0.0) && (*abserr != 0.0))
+    *abserr = (*resasc) * min(1.0, pow((200.0 * (*abserr) / (*resasc)), 1.5));
+  if (*resabs > uflow / (50.0 * epmach))
+    *abserr = max(epmach * 50.0 * (*resabs), (*abserr));
+  return result;
 }


### PR DESCRIPTION
The current modern CMake versions cannot build the package because of the `cmake_minimum_required(VERSION 3.0)`.

Changing it to be >= 3.6 will allow modern toolchains to build the package, making it usable again.

Moreover, when attempting to build following the version change, on gcc 15.2.1 20251112, the following error occured:

```
NumbaQuadpack/src/dqc25c.c:51:23: error: passing argument 2 of ‘G_K15W’ from incompatible pointer type [-Wincompatible-pointer-types]
   51 |     result = G_K15W(f,dqwgtc,c,p2,p3,p4,kp,a,b,abserr,&resabs,&resasc, user_data);
      |                       ^~~~~~
      |                       |
      |                       double (*)(double,  double,  double,  double,  double,  int)
```

by introducing `dq_weight_function_type` this error no longer occurs and the library builds, so does the python package. 